### PR TITLE
Use yt-dlp instead of youtube-dl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ ENV USER ts3bot
 # install all pre-requisites, these will be needed always
 RUN apk add \
     opus-dev \
-    youtube-dl \
     ffmpeg
+    
+#download yt-dlp
+RUN wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/yt-dlp
+RUN chmod +x /usr/local/yt-dlp
+
 
 # download and install the TS3AudioBot in the specified version and flavour
 RUN mkdir -p /app \


### PR DESCRIPTION
youtube-dl is not getting a lot of active development, breaks constantly through chances made at YouTube and fixes for those changes are released very slowly. yt-dlp is a more actively maintained fork.